### PR TITLE
Added IdentityDistribution class in diffusers vae

### DIFF
--- a/hack_codes/models/vae.py
+++ b/hack_codes/models/vae.py
@@ -755,7 +755,16 @@ class DiagonalGaussianDistribution(object):
 
     def mode(self):
         return self.mean
+        
+class IdentityDistribution(object):
+    def __init__(self, parameters: torch.Tensor):
+        self.parameters = parameters
 
+    def sample(self, generator: Optional[torch.Generator] = None) -> torch.Tensor:
+        return self.parameters
+
+    def mode(self) -> torch.Tensor:
+        return self.parameters
 
 class EncoderTiny(nn.Module):
     def __init__(


### PR DESCRIPTION
Added IdentityDistribution class in diffusers vae in response to the following error:

```
(cocolc) swarnim@AI-CoE:~/COCO-LC$ python test.py --input_dir ./input_images --output_dir ./output_images --cfg_scale 7.5 --fantastic_neg_prompt True
Traceback (most recent call last):
  File "/data/swarnim/COCO-LC/diffusers/src/diffusers/utils/import_utils.py", line 883, in _get_module
    return importlib.import_module("." + module_name, self.__name__)
  File "/data/swarnim/anaconda3/envs/cocolc/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 961, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 843, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/data/swarnim/COCO-LC/diffusers/src/diffusers/models/autoencoders/__init__.py", line 6, in <module>
    from .autoencoder_kl_cosmos import AutoencoderKLCosmos
  File "/data/swarnim/COCO-LC/diffusers/src/diffusers/models/autoencoders/autoencoder_kl_cosmos.py", line 27, in <module>
    from .vae import DecoderOutput, IdentityDistribution
ImportError: cannot import name 'IdentityDistribution' from 'diffusers.models.autoencoders.vae' (/data/swarnim/COCO-LC/diffusers/src/diffusers/models/autoencoders/vae.py)

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "test.py", line 6, in <module>
    from diffusers import (
  File "<frozen importlib._bootstrap>", line 1039, in _handle_fromlist
  File "/data/swarnim/COCO-LC/diffusers/src/diffusers/utils/import_utils.py", line 874, in __getattr__
    value = getattr(module, name)
  File "/data/swarnim/COCO-LC/diffusers/src/diffusers/utils/import_utils.py", line 873, in __getattr__
    module = self._get_module(self._class_to_module[name])
  File "/data/swarnim/COCO-LC/diffusers/src/diffusers/utils/import_utils.py", line 885, in _get_module
    raise RuntimeError(
RuntimeError: Failed to import diffusers.models.autoencoders.autoencoder_kl because of the following error (look up to see its traceback):
cannot import name 'IdentityDistribution' from 'diffusers.models.autoencoders.vae' (/data/swarnim/COCO-LC/diffusers/src/diffusers/models/autoencoders/vae.py)
```